### PR TITLE
Create wall-builder mode

### DIFF
--- a/src/client/components/map_tile/index.jsx
+++ b/src/client/components/map_tile/index.jsx
@@ -38,11 +38,11 @@ const MapTile = ({ code, isSelected, handleTileClick }) => {
 MapTile.propTypes = {
   code: PropTypes.string.isRequired,
   handleTileClick: PropTypes.func.isRequired,
-  isSelected: PropTypes.shape(),
+  isSelected: PropTypes.bool,
 };
 
 MapTile.defaultProps = {
-  isSelected: {},
+  isSelected: false,
 };
 
 export default MapTile;

--- a/src/client/containers/map_legend/index.jsx
+++ b/src/client/containers/map_legend/index.jsx
@@ -48,11 +48,12 @@ class MapLegend extends Component {
   }
 
   renderMapTiles() {
-    const { selectedTile } = this.props;
+    const { selectedTile: { tileCode } } = this.props;
     return Object.keys(spriteData).map(key => (
       <MapTile
+        key={key}
         code={key}
-        isSelected={selectedTile.tileCode === key}
+        isSelected={tileCode && tileCode === key}
         handleTileClick={this.handleTileClick}
       />
     ));

--- a/src/client/containers/stage/index.jsx
+++ b/src/client/containers/stage/index.jsx
@@ -56,6 +56,11 @@ class Stage extends Component {
     this.kickoffAnimationFrames();
   }
 
+  componentWillUnmount() {
+    console.log('Unmounting Stage -- clearing requestAnimationFrame');
+    this.handleAnimationFrameStop();
+  }
+
   gameStart({ context }) {
     this.setState({ context }, () => {
       this.initializeContextValues();

--- a/src/client/dux/map_builder.js
+++ b/src/client/dux/map_builder.js
@@ -1,24 +1,24 @@
 import update from 'immutability-helper';
 import { createAction } from 'redux-actions';
 
+import { cellTypes } from '@utils/constants';
+
 // Actions
-const UPDATE_SELECTED_CELL = 'map_builder/UPDATE_SELECTED_CELL';
 const UPDATE_SELECTED_TILE = 'map_builder/UPDATE_SELECTED_TILE';
 const UPDATE_IMPASSABLE_COORDINATE_MATRIX = 'map_builder/UPDATE_IMPASSABLE_COORDINATE_MATRIX';
 const UPDATE_IMAGE_BLOB = 'map_builder/UPDATE_IMAGE_BLOB';
 const UPDATE_HOVERED_CELL = 'map_builder/UPDATE_HOVERED_CELL';
-const UPDATE_GRID_MATRIX = 'map_builder/UPDATE_GRID_MATRIX';
 const INITIALIZE_GRID_OBJECT = 'map_builder/INITIALIZE_GRID_OBJECT';
 const UPDATE_GRID_OBJECT = 'map_builder/UPDATE_GRID_OBJECT';
 
 // Reducer
 const initialState = {
-  gridMatrix: [],
   gridObject: {},
   hoveredCell: {},
-  selectedCell: null, // XY COORDS - set a default here!
+  lastClickedCell: null,
   selectedTile: {},
-  impassableCoordinateMatrix: null, // ARRAY
+  selectedCellType: cellTypes.floor,
+  impassableCoordinateObject: {},
   imageBlob: null, // FILE (IMAGE BLOB)
 };
 
@@ -38,12 +38,6 @@ export default function mapBuilderReducer(state = initialState, action = {}) {
     case UPDATE_HOVERED_CELL: {
       return update(state, { hoveredCell: { $merge: payload } });
     }
-    case UPDATE_GRID_MATRIX: {
-      return update(state, { gridMatrix: { $set: payload } });
-    }
-    case UPDATE_SELECTED_CELL: {
-      return update(state, { selectedCell: { $set: payload } });
-    }
     case UPDATE_SELECTED_TILE: {
       return update(state, { selectedTile: { $set: payload } });
     }
@@ -60,12 +54,9 @@ export default function mapBuilderReducer(state = initialState, action = {}) {
 }
 
 // Action Creators
-// export const updateContext = createAction(UPDATE_CONTEXT);
-export const updateSelectedCell = createAction(UPDATE_SELECTED_CELL);
 export const updateSelectedTile = createAction(UPDATE_SELECTED_TILE);
 export const updateImpassableCoordinateMatrix = createAction(UPDATE_IMPASSABLE_COORDINATE_MATRIX);
 export const updateImageBlob = createAction(UPDATE_IMAGE_BLOB);
 export const updateHoveredCell = createAction(UPDATE_HOVERED_CELL);
-export const updateGridMatrix = createAction(UPDATE_GRID_MATRIX);
 export const initializeGridObject = createAction(INITIALIZE_GRID_OBJECT);
 export const updateGridObject = createAction(UPDATE_GRID_OBJECT);

--- a/src/client/index.jsx
+++ b/src/client/index.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render } from 'react-dom';
-import { BrowserRouter as Router } from 'react-router-dom';
+import { Router } from 'react-router-dom';
 import createHistory from 'history/createBrowserHistory';
 import { createStore, applyMiddleware, compose } from 'redux';
 import { Provider } from 'react-redux';

--- a/src/client/utils/constants.js
+++ b/src/client/utils/constants.js
@@ -44,6 +44,7 @@ export const spriteData = {
 // =================
 // Tile/Grid Constants
 // =================
+const hoverOpacity = '0.5';
 export const tileSpecs = {
   tileSize: 96,
   spriteSpecs: {
@@ -59,8 +60,14 @@ export const tileSpecs = {
 };
 
 export const gridColors = {
-  mapMode: '#000',
-  wallMode: '#f00',
+  mapBuilderMode: {
+    grid: '#000',
+    highlight: `rgba(255, 255, 255, ${hoverOpacity})`,
+  },
+  wallBuilderMode: {
+    grid: '#f00',
+    highlight: `rgba(1, 139, 247, ${hoverOpacity})`,
+  },
 };
 
 export const gridSpecs = {
@@ -69,9 +76,23 @@ export const gridSpecs = {
   cols: 12,
 };
 
+export const cellTypes = {
+  floor: {
+    name: 'envSprite',
+    impassable: false,
+    highlight: 'rgba(0, 0, 0, 0)',
+  },
+  wall: {
+    name: 'wall',
+    impassable: true,
+    highlight: `rgba(255, 0, 0, ${hoverOpacity})`,
+  },
+};
+
 export default {
   spriteData,
   tileSpecs,
   gridSpecs,
   gridColors,
+  cellTypes,
 };


### PR DESCRIPTION
    * implemented react-router-dom
    * updated nav header
    * updated `drawPaintedCells` to handle rendering in wall mode
    * added wall mode functionality to MapBuilder
    * added more grid and cell data to constants (colors mainly)
    * add toggle button to switch between map and wall modes
    * removed `update` call from canvas click handler
    * removed unneeded state from map_builder duck
    * removed `context.globalAlpha` and used rgba for highlight colors
    * `gridObject` state can now store `cellType` for wall vs floor cells